### PR TITLE
feat: 글로벌 헤더 UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.0",
+    "@mui/icons-material": "^6.3.1",
     "@mui/material": "^6.3.0",
     "next": "15.0.3",
     "react": "19",

--- a/src/shared/styles/device.ts
+++ b/src/shared/styles/device.ts
@@ -1,0 +1,17 @@
+const size = {
+  mobile: 320,
+  smallTablet: 600,
+  tablet: 768,
+  desktop: 1024,
+};
+
+export const device = {
+  mobile: `(min-width: ${size.mobile}px)`,
+  smallTablet: `(min-width: ${size.smallTablet}px)`,
+  tablet: `(min-width: ${size.tablet}px)`,
+  desktop: `(min-width: ${size.desktop}px)`,
+};
+
+export const DESKTOP = `@media ${device.desktop}`;
+export const TABLET = `@media ${device.tablet}`;
+export const SMALL_TABLET = `@media ${device.smallTablet}`;

--- a/src/shared/styles/index.ts
+++ b/src/shared/styles/index.ts
@@ -1,0 +1,2 @@
+export { default as colors } from './colors.ts';
+export * from './device.ts';

--- a/src/widgets/layouts/GlobalNav/index.ts
+++ b/src/widgets/layouts/GlobalNav/index.ts
@@ -1,1 +1,0 @@
-export * from './template';

--- a/src/widgets/layouts/GlobalNav/template.tsx
+++ b/src/widgets/layouts/GlobalNav/template.tsx
@@ -1,3 +1,0 @@
-export function GlobalNav() {
-  return <nav>Global Nav</nav>;
-}

--- a/src/widgets/layouts/Header/style.ts
+++ b/src/widgets/layouts/Header/style.ts
@@ -1,0 +1,27 @@
+import AppBar from '@mui/material/AppBar';
+import Toolbar from '@mui/material/Toolbar';
+import styled from '@emotion/styled';
+import colors from '@/shared/styles/colors';
+
+export const Container = styled(AppBar)`
+  background-color: ${colors.white};
+  box-shadow: none;
+  border-bottom: 1px solid ${colors.gray[300]};
+`;
+
+export const ToolbarContainer = styled(Toolbar)`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  height: 60px;
+`;
+
+export const Logo = styled.h1`
+  cursor: pointer;
+`;
+
+export const RightIcons = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 16px;
+`;

--- a/src/widgets/layouts/Header/style.ts
+++ b/src/widgets/layouts/Header/style.ts
@@ -1,7 +1,7 @@
 import AppBar from '@mui/material/AppBar';
 import Toolbar from '@mui/material/Toolbar';
 import styled from '@emotion/styled';
-import colors from '@/shared/styles/colors';
+import { colors, DESKTOP } from '@/shared/styles';
 
 export const Container = styled(AppBar)`
   background-color: ${colors.white};
@@ -13,7 +13,11 @@ export const ToolbarContainer = styled(Toolbar)`
   display: flex;
   justify-content: space-between;
   align-items: center;
-  height: 60px;
+  height: 50px;
+
+  ${DESKTOP} {
+    height: 60px;
+  }
 `;
 
 export const Logo = styled.h1`

--- a/src/widgets/layouts/Header/style.ts
+++ b/src/widgets/layouts/Header/style.ts
@@ -20,7 +20,7 @@ export const ToolbarContainer = styled(Toolbar)`
   }
 `;
 
-export const Logo = styled.h1`
+export const Logo = styled.div`
   cursor: pointer;
 `;
 

--- a/src/widgets/layouts/Header/template.tsx
+++ b/src/widgets/layouts/Header/template.tsx
@@ -34,25 +34,26 @@ export function Header() {
     <HideOnScroll>
       <S.Container position="static" color="secondary">
         <S.ToolbarContainer>
-          {/* 로고를 클릭하면 홈으로 이동 */}
+          {/* 로고 - 홈으로 이동 */}
           <S.Logo>
             <Link href="/">MONEYLOG</Link>
           </S.Logo>
 
           {/* 헤더 우측 버튼들 */}
           <S.RightIcons>
-            {/* 게시물 작성 페이지로 이동 */}
+            {/* 1. 게시물 작성 페이지로 이동 */}
             <Link href="/write">
               <IconButton color="inherit">
                 <EditIcon />
               </IconButton>
             </Link>
-            {/* 알림 */}
+            {/* 2. 알림 */}
             <IconButton color="inherit">
               <NotificationsIcon />
             </IconButton>
-            {/* 사용자 프로필 or 로그인/회원가입 */}
+            {/* 3. 사용자 프로필 or 로그인/회원가입 */}
             <IconButton color="inherit">
+              {/** 기본 이미지 추가 필요 */}
               <Avatar alt="유저 프로필" src="" />
             </IconButton>
           </S.RightIcons>

--- a/src/widgets/layouts/Header/template.tsx
+++ b/src/widgets/layouts/Header/template.tsx
@@ -1,9 +1,63 @@
-import { GlobalNav } from '../GlobalNav';
+'use client';
+import React, { useState, useEffect } from 'react';
+import IconButton from '@mui/material/IconButton';
+import Avatar from '@mui/material/Avatar';
+import NotificationsIcon from '@mui/icons-material/Notifications';
+import EditIcon from '@mui/icons-material/Edit';
+import Slide from '@mui/material/Slide';
+import Link from 'next/link';
+
+import * as S from './style.ts';
+
+function HideOnScroll(props) {
+  const { children } = props;
+  const [trigger, setTrigger] = useState(false);
+
+  useEffect(() => {
+    const handleScroll = () => {
+      setTrigger(window.scrollY > 100);
+    };
+
+    window.addEventListener('scroll', handleScroll);
+    return () => window.removeEventListener('scroll', handleScroll);
+  }, []);
+
+  return (
+    <Slide appear={false} direction="down" in={!trigger}>
+      {children}
+    </Slide>
+  );
+}
 
 export function Header() {
   return (
-    <header>
-      Header <GlobalNav />
-    </header>
+    <HideOnScroll>
+      <S.Container position="static" color="secondary">
+        <S.ToolbarContainer>
+          {/* 로고를 클릭하면 홈으로 이동 */}
+          <S.Logo>
+            <Link href="/">MONEYLOG</Link>
+          </S.Logo>
+
+          {/* 헤더 우측 버튼들 */}
+          <S.RightIcons>
+            {/* 게시물 작성 페이지로 이동 */}
+            <Link href="/write">
+              <IconButton color="inherit">
+                <EditIcon />
+              </IconButton>
+            </Link>
+            {/* 알림 */}
+            <IconButton color="inherit">
+              <NotificationsIcon />
+            </IconButton>
+            {/* 사용자 프로필 or 로그인/회원가입 */}
+            <IconButton color="inherit">
+              <Avatar alt="유저 프로필" src="" />
+            </IconButton>
+          </S.RightIcons>
+        </S.ToolbarContainer>
+      </S.Container>
+    </HideOnScroll>
   );
 }

--- a/src/widgets/layouts/Header/template.tsx
+++ b/src/widgets/layouts/Header/template.tsx
@@ -2,8 +2,8 @@
 import React, { useState, useEffect } from 'react';
 import IconButton from '@mui/material/IconButton';
 import Avatar from '@mui/material/Avatar';
-import NotificationsIcon from '@mui/icons-material/Notifications';
-import EditIcon from '@mui/icons-material/Edit';
+import NotificationsIcon from '@mui/icons-material/NotificationsOutlined';
+import EditIcon from '@mui/icons-material/EditOutlined';
 import Slide from '@mui/material/Slide';
 import Link from 'next/link';
 

--- a/src/widgets/layouts/index.ts
+++ b/src/widgets/layouts/index.ts
@@ -1,3 +1,2 @@
 export * from './Footer';
-export * from './GlobalNav';
 export * from './Header';

--- a/yarn.lock
+++ b/yarn.lock
@@ -746,6 +746,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@mui/icons-material@npm:^6.3.1":
+  version: 6.3.1
+  resolution: "@mui/icons-material@npm:6.3.1"
+  dependencies:
+    "@babel/runtime": "npm:^7.26.0"
+  peerDependencies:
+    "@mui/material": ^6.3.1
+    "@types/react": ^17.0.0 || ^18.0.0 || ^19.0.0
+    react: ^17.0.0 || ^18.0.0 || ^19.0.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10c0/edaf71b7368c14cfbfed6f475ef96187871a010e972b9e7608d23cadae5ce52a3a6888b32453721dc1d86e2e7ad9c61aadde83ba5cd94363782bf83803d1ab36
+  languageName: node
+  linkType: hard
+
 "@mui/material@npm:^6.3.0":
   version: 6.3.0
   resolution: "@mui/material@npm:6.3.0"
@@ -4228,6 +4244,7 @@ __metadata:
     "@commitlint/config-conventional": "npm:^19.6.0"
     "@emotion/react": "npm:^11.14.0"
     "@emotion/styled": "npm:^11.14.0"
+    "@mui/icons-material": "npm:^6.3.1"
     "@mui/material": "npm:^6.3.0"
     "@types/node": "npm:^20"
     "@types/react": "npm:^18"


### PR DESCRIPTION
## 글로벌 헤더 UI

### **개발 사항**
- **MUI 기반 UI 개발**
  - MUI(AppBar, Toolbar, IconButton 등) 컴포넌트를 사용하여 헤더 UI를 구현
  - 로고, 글쓰기 버튼, 알림 아이콘, 사용자 프로필 아이콘 포함
  
- **스크롤 시 숨겨지는 기능**
  - `useScrollTrigger` 훅과 `Slide` 컴포넌트를 사용하여 스크롤 시 헤더가 숨겨지도록 구현
  - 스크롤 시 `window.scrollY` 값을 기반으로 헤더의 노출 여부를 동적으로 제어

### **기타 사항**
- **기존 글로벌 내비게이션 컴포넌트 제거**
  - 페이지 이동이 많이 필요하지 않다는 판단하에 기존에 작성된 글로벌 내비게이션 컴포넌트를 제거
  - 페이지 이동을 위한 추가적인 내비게이션 요소는 헤더 외에 다른 방식으로 관리될 예정

<!-- This is an auto-generated comment: release notes by coderabbit.ai
## Summary by CodeRabbit

- **제거된 기능**
  - 글로벌 내비게이션 컴포넌트가 애플리케이션에서 완전히 제거되었습니다.
  - 내비게이션 관련 모듈의 모든 익스포트가 비활성화되었습니다.

- **새로운 기능**
  - 스크롤에 따라 자식 요소의 가시성을 관리하는 `HideOnScroll` 컴포넌트가 추가되었습니다.

- **스타일**
  - 새로운 스타일 컴포넌트가 헤더에 추가되어 사용자 인터페이스가 개선되었습니다.

- **의존성 추가**
  - `@mui/icons-material` 패키지가 프로젝트에 추가되었습니다.

- **새로운 반응형 디자인**
  - 다양한 장치 크기에 대한 반응형 디자인을 정의하는 새로운 파일이 추가되었습니다.
-->